### PR TITLE
Add Intervals option to the Stats server

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -629,11 +629,11 @@ unsigned long int client_group::get_duration_usec(void)
     return duration;
 }
 
-one_second_stats client_group::get_one_min_stats()
+one_second_stats client_group::get_interval_stats()
 {
     one_second_stats stats(0);
     for (std::vector<client*>::iterator i = m_clients.begin(); i != m_clients.end(); i++) {
-        stats.merge((*i)->get_stats()->get_one_min_cmd_stats());
+        stats.merge((*i)->get_stats()->get_interval_cmd_stats());
     }
     return stats;
 }

--- a/client.cpp
+++ b/client.cpp
@@ -629,11 +629,11 @@ unsigned long int client_group::get_duration_usec(void)
     return duration;
 }
 
-one_second_stats client_group::get_interval_stats()
+one_second_stats client_group::get_interval_stats(unsigned short interval)
 {
     one_second_stats stats(0);
     for (std::vector<client*>::iterator i = m_clients.begin(); i != m_clients.end(); i++) {
-        stats.merge((*i)->get_stats()->get_interval_cmd_stats());
+        stats.merge((*i)->get_stats()->get_interval_cmd_stats(interval));
     }
     return stats;
 }

--- a/client.h
+++ b/client.h
@@ -186,7 +186,7 @@ public:
     unsigned long int get_total_latency(void);
     unsigned long int get_duration_usec(void);
 
-    one_second_stats get_one_min_stats();
+    one_second_stats get_interval_stats();
     void merge_run_stats(run_stats* target);
 };
 

--- a/client.h
+++ b/client.h
@@ -186,7 +186,7 @@ public:
     unsigned long int get_total_latency(void);
     unsigned long int get_duration_usec(void);
 
-    one_second_stats get_interval_stats();
+    one_second_stats get_interval_stats(unsigned short interval);
     void merge_run_stats(run_stats* target);
 };
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1033,8 +1033,8 @@ run_stats run_benchmark(int run_id, benchmark_config* cfg, object_generator* obj
         active_threads = 0;
         sleep(1);
 
-        // Collect last 60 sec stats
-        if(processed_seconds % 60 == 0) {
+        // Collect last 15 sec stats
+        if(processed_seconds % 15 == 0) {
             web_server->calc_last_minute_stats(threads, cfg->print_percentiles.quantile_list);
             processed_seconds = 0;
         }

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -918,6 +918,7 @@ void usage() {
             "      --print-percentiles        Specify which percentiles info to print on the results table (by default prints percentiles: 50,99,99.9)\n"
             "      --cluster-mode             Run client in cluster mode\n"
             "      --api-port=PORT            Local API Stats Server port (default: 8081)\n"
+            "      --api-report-interval      API Stats calculation interval in seconds (default: 60)\n"
             "  -h, --help                     Display this help\n"
             "  -v, --version                  Display version information\n"
             "\n"
@@ -1048,7 +1049,7 @@ run_stats run_benchmark(int run_id, benchmark_config* cfg, object_generator* obj
 
         // Collect last n sec stats
         if(processed_seconds % cfg->api_report_interval == 0) {
-            web_server->calc_last_interval_stats(threads, cfg->print_percentiles.quantile_list);
+            web_server->calc_last_interval_stats(threads, cfg->print_percentiles.quantile_list, cfg->api_report_interval);
             processed_seconds = 0;
         }
         processed_seconds++;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -105,6 +105,7 @@ struct benchmark_config {
     SSL_CTX *openssl_ctx;
 #endif
     unsigned short api_port;
+    unsigned short api_report_interval;
 };
 
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -304,9 +304,9 @@ void run_stats::save_csv_one_sec(FILE *f,
     }
 }
 
-one_second_stats run_stats::get_one_min_cmd_stats() {
+one_second_stats run_stats::get_interval_cmd_stats(unsigned short interval) {
     one_second_stats result(0);
-    int sec_remaining = 15;
+    int sec_remaining = interval;
     std::list<one_second_stats>::iterator i = m_stats.end();
     while (sec_remaining > 0 && i != m_stats.begin()) {
       i--;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -306,7 +306,7 @@ void run_stats::save_csv_one_sec(FILE *f,
 
 one_second_stats run_stats::get_one_min_cmd_stats() {
     one_second_stats result(0);
-    int sec_remaining = 60;
+    int sec_remaining = 15;
     std::list<one_second_stats>::iterator i = m_stats.end();
     while (sec_remaining > 0 && i != m_stats.begin()) {
       i--;

--- a/run_stats.h
+++ b/run_stats.h
@@ -130,7 +130,7 @@ public:
     void aggregate_average(const std::vector<run_stats>& all_stats);
     void summarize(totals& result) const;
     void merge(const run_stats& other, int iteration);
-    one_second_stats get_one_min_cmd_stats();
+    one_second_stats get_interval_cmd_stats(unsigned short interval);
     std::vector<one_sec_cmd_stats> get_one_sec_cmd_stats_get();
     std::vector<one_sec_cmd_stats> get_one_sec_cmd_stats_set();
     std::vector<one_sec_cmd_stats> get_one_sec_cmd_stats_wait();

--- a/stats_web_server.h
+++ b/stats_web_server.h
@@ -51,7 +51,7 @@ class StatsWebServer {
         const double sec_min_latency = has_samples ? hdr_min(cmd_stats.latency_histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
         const double sec_max_latency = has_samples ? hdr_max(cmd_stats.latency_histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
         json_str += "\"Count\":" + std::to_string(hdr_total_count(cmd_stats.latency_histogram)) + ",";
-        json_str += "\"OpsPerSecond\":" + std::to_string(cmd_stats.m_ops/60) + ",";
+        json_str += "\"OpsPerSecond\":" + std::to_string(cmd_stats.m_ops/15) + ",";
         json_str += "\"AverageLatency\":" + double_to_str(sec_avg_latency) + ",";
         json_str += "\"MinLatency\":" + double_to_str(sec_min_latency) + ",";
         json_str += "\"MaxLatency\":" + double_to_str(sec_max_latency) + ",";

--- a/stats_web_server.h
+++ b/stats_web_server.h
@@ -1,5 +1,5 @@
 
-static std::string last_minute_json_stats = "{}";
+static std::string last_interval_json_stats = "{}";
 static std::mutex stats_mutex;
 
 std::string double_to_str(const double value) {
@@ -13,12 +13,13 @@ class StatsWebServer {
     std::promise<void> signal_exit; //A promise object
     std::thread serve_http_thread;
     unsigned short api_port;
+    unsigned short api_report_interval;
 
     static void serve_request(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
         if (ev == MG_EV_HTTP_MSG) {
           struct mg_http_message *hm = (struct mg_http_message *) ev_data;
           if (mg_http_match_uri(hm, "/api/lastminstats")) {
-            const char* stats = last_minute_json_stats.c_str();
+            const char* stats = last_interval_json_stats.c_str();
             fprintf(stderr, "Stats API Response: %s\n", stats);
             mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s", stats);  // Serve dynamic content
           } else {
@@ -42,16 +43,17 @@ class StatsWebServer {
         mg_mgr_free(&mgr);                                      // Cleanup
     }
 
-    std::string get_one_minute_stats_json(one_sec_cmd_stats cmd_stats, std::vector<float> quantile_list){
+    std::string get_last_m_sec_stats_json(one_sec_cmd_stats cmd_stats, std::vector<float> quantile_list){
         std::string json_str = "";
         json_str+="{";
+        unsiged short interval = cfg->api_report_interval;
         const bool has_samples = hdr_total_count(cmd_stats.latency_histogram)>0;
         const bool sec_has_samples = hdr_total_count(cmd_stats.latency_histogram)>0;
         const double sec_avg_latency = sec_has_samples ? hdr_mean(cmd_stats.latency_histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
         const double sec_min_latency = has_samples ? hdr_min(cmd_stats.latency_histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
         const double sec_max_latency = has_samples ? hdr_max(cmd_stats.latency_histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
         json_str += "\"Count\":" + std::to_string(hdr_total_count(cmd_stats.latency_histogram)) + ",";
-        json_str += "\"OpsPerSecond\":" + std::to_string(cmd_stats.m_ops/15) + ",";
+        json_str += "\"OpsPerSecond\":" + std::to_string(cmd_stats.m_ops/interval) + ",";
         json_str += "\"AverageLatency\":" + double_to_str(sec_avg_latency) + ",";
         json_str += "\"MinLatency\":" + double_to_str(sec_min_latency) + ",";
         json_str += "\"MaxLatency\":" + double_to_str(sec_max_latency) + ",";
@@ -71,8 +73,9 @@ class StatsWebServer {
     }
 
     public:
-    StatsWebServer(unsigned short api_port) {
+    StatsWebServer(unsigned short api_port, unsigned short api_report_interval) {
       this->api_port = api_port;
+      this->api_report_interval = api_report_interval;
     }
 
     void start_server() {
@@ -85,19 +88,19 @@ class StatsWebServer {
         serve_http_thread.join();
     }
 
-    void calc_last_minute_stats(std::vector<cg_thread*> threads, std::vector<float> quantile_list) {
+    void calc_last_interval_stats(std::vector<cg_thread*> threads, std::vector<float> quantile_list) {
         one_second_stats stats(0);
         for (std::vector<cg_thread*>::iterator i = threads.begin(); i != threads.end(); i++) {
-            stats.merge((*i)->m_cg->get_one_min_stats());
+            stats.merge((*i)->m_cg->get_interval_stats());
         }
         std::string json_str = "";
         json_str += "{\"GetStats\":";
-        json_str += get_one_minute_stats_json(stats.m_set_cmd, quantile_list);
+        json_str += get_last_m_sec_stats_json(stats.m_set_cmd, quantile_list);
         json_str += ",\"SetStats\":";
-        json_str += get_one_minute_stats_json(stats.m_get_cmd, quantile_list);
+        json_str += get_last_m_sec_stats_json(stats.m_get_cmd, quantile_list);
         json_str += "}";
         stats_mutex.lock();
-        last_minute_json_stats = json_str;
+        last_interval_json_stats = json_str;
         stats_mutex.unlock();
     }
 };


### PR DESCRIPTION
This PR includes the following:
  * Add --api-report-interval to support on reporting for last m seconds (10 to 60)
  * Update code to group stats for specific intervals